### PR TITLE
Compatibility Fix with Crusader Kings 3.3.*

### DIFF
--- a/tributary_vassals.mod
+++ b/tributary_vassals.mod
@@ -1,8 +1,7 @@
-	name="Autonomous Dependent States"
-	path="mod/tributary_vassals"
-	tags=
-	{
-		Tributary Vassals Release Vassals Tributaries Autonomous States fearmods 
-	}
-	picture="thumbnail.jpg"
+name="Autonomous Dependent States War Variant [3.3.*]"
+path="mod/tributary_vassals"
+tags=
+{
+	Tributary Vassals Release Vassals Tributaries Autonomous States fearmods 
 }
+picture="thumbnail.jpg"


### PR DESCRIPTION
the new update adds two descriptor.mod files in the zip file, if the steam mod name is different than in-game/descriptor mod name which breaks the mod.